### PR TITLE
remove doubled attribute getter

### DIFF
--- a/k8s-events-to-slack-streamer.py
+++ b/k8s-events-to-slack-streamer.py
@@ -101,7 +101,7 @@ def stream_events(kubernetes, k8s_namespace_name, timeout):
     v1 = kubernetes.client.CoreV1Api()
     k8s_watch = kubernetes.watch.Watch()
     if k8s_namespace_name:
-        return k8s_watch.stream(v1.v1.list_namespaced_event, k8s_namespace_name, timeout_seconds=timeout)
+        return k8s_watch.stream(v1.list_namespaced_event, k8s_namespace_name, timeout_seconds=timeout)
     else:
         return k8s_watch.stream(v1.list_event_for_all_namespaces, timeout_seconds=timeout)
 


### PR DESCRIPTION
This project does not have an issue tracker (please consider opening it, the original repo is read only and so also cannot have new issues created), so here is a PR instead.

I installed this into the `production` namespace, but it just crashes with 

```
Failed to process events with error: Unexpected error:
Traceback (most recent call last):
 File "/app/k8s-events-to-slack-streamer.py", line 142, in main
   for event in stream_events(kubernetes, k8s_namespace_name, 7200):
 File "/app/k8s-events-to-slack-streamer.py", line 100, in stream_events
   return k8s_watch.stream(v1.v1.list_namespaced_event, k8s_namespace_name, timeout_seconds=timeout)
AttributeError: 'CoreV1Api' object has no attribute 'v1'
```

Line 104 has what looks like an erroneously doubled `v1`, and this PR removes one of them.

This error only occurs if you define `K8S_EVENTS_STREAMER_NAMESPACE`

https://github.com/teochenglim/kubernetes-events-to-slack/blob/231c5108aa8705e94ffab6332bb06bb96d21430b/k8s-events-to-slack-streamer.py#L100-L107

This code has not been tested.

As a work around, I removed `K8S_EVENTS_STREAMER_NAMESPACE`.